### PR TITLE
Don't run on browser start

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
 			"dependencies": {
 				"webext-content-scripts": "^2.6.1",
 				"webext-detect-page": "^5.0.1",
-				"webext-events": "^2.2.2",
+				"webext-events": "^2.3.0",
 				"webext-polyfill-kinda": "^1.0.2"
 			},
 			"devDependencies": {
@@ -8967,9 +8967,9 @@
 			}
 		},
 		"node_modules/webext-events": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/webext-events/-/webext-events-2.2.2.tgz",
-			"integrity": "sha512-ZJxCIzhkj9MhqtYeN6nPIuH3N/qi+prcRNL0cXRx0JohnSuhlp4eZWuYBHAS+JGlq/BUnbB82ojZ62QOwR/caQ==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/webext-events/-/webext-events-2.3.0.tgz",
+			"integrity": "sha512-3irAy/AUT7cxjH1KQ6ari9Dv5wkVbjMpF5Rid1hk7/3lm7ebQYvO4PoF3LwnJAhFjhVPO7jwJy5DcgHXjdmvNA==",
 			"dependencies": {
 				"webext-detect-page": "^5.0.1"
 			},

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
 	"dependencies": {
 		"webext-content-scripts": "^2.6.1",
 		"webext-detect-page": "^5.0.1",
-		"webext-events": "^2.2.2",
+		"webext-events": "^2.3.0",
 		"webext-polyfill-kinda": "^1.0.2"
 	},
 	"devDependencies": {

--- a/source/register.ts
+++ b/source/register.ts
@@ -1,18 +1,23 @@
 import {onExtensionStart} from 'webext-events';
 import progressivelyInjectScript from './inject.js';
 
+function register() {
+	const {content_scripts: scripts} = chrome.runtime.getManifest();
+
+	if (!scripts?.length) {
+		throw new Error('webext-inject-on-install tried to inject content scripts, but no content scripts were found in the manifest.');
+	}
+
+	console.debug('webext-inject-on-install: Found', scripts.length, 'content script(s) in the manifest.');
+
+	for (const contentScript of scripts) {
+		void progressivelyInjectScript(contentScript);
+	}
+}
+
 if (globalThis.chrome && !navigator.userAgent.includes('Firefox')) {
-	onExtensionStart.addListener(() => {
-		const {content_scripts: scripts} = chrome.runtime.getManifest();
-
-		if (!scripts?.length) {
-			throw new Error('webext-inject-on-install tried to inject content scripts, but no content scripts were found in the manifest.');
-		}
-
-		console.debug('webext-inject-on-install: Found', scripts.length, 'content script(s) in the manifest.');
-
-		for (const contentScript of scripts) {
-			void progressivelyInjectScript(contentScript);
-		}
+	onExtensionStart.addListener(register);
+	chrome.runtime.onStartup.addListener(() => {
+		onExtensionStart.removeListener(register);
 	});
 }


### PR DESCRIPTION
- Includes https://github.com/fregante/webext-events/pull/22
- Fixes https://github.com/fregante/webext-inject-on-install/issues/10

It probably isn't needed after https://github.com/fregante/webext-inject-on-install/pull/12, so I'll keep this PR open until I see how PixieBrix behaves 


Next:

- [x] Verify the order of execution: onStartup should fire before `onExtensionStart`